### PR TITLE
Initialize bulkrax settings

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/BlockLength
+Rails.application.config.after_initialize do
+  Bulkrax.setup do |config|
+    # Add or remove local parsers
+    # Keep only CSV parser
+    config.parsers = [
+      { name: "CSV - Comma Separated Values", class_name: "Bulkrax::CsvParser", partial: "csv_fields" }
+    ]
+
+    # WorkType to use as the default if none is specified in the import
+    # Default is the first returned by Hyrax.config.curation_concerns, stringified
+    # config.default_work_type = "GenericWorkResource"
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/config/initializers/default_bulkrax_mappings.rb
+++ b/config/initializers/default_bulkrax_mappings.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# This lambda is used to set the default field mapping for Bulkrax:
+# conf.default_field_mapping = lambda do |field|
+#   return if field.blank?
+#   {
+#     field.to_s =>
+#     {
+#       from: [field.to_s],
+#       split: false,
+#       parsed: Bulkrax::ApplicationMatcher.method_defined?("parse_#{field}"),
+#       if: nil,
+#       excluded: false
+#     }
+#   }
+# end
+
+## Set custom bulkrax parser field mappings for app if not using above
+# parser_mappings = {
+
+# }
+
+# # all parsers use the same mappings:
+# mappings = {}
+# mappings["Bulkrax::CsvParser"] = parser_mappings
+# Hyku.default_bulkrax_field_mappings = mappings


### PR DESCRIPTION
# Story

Refs https://github.com/notch8/wvu_knapsack/issues/14

# Expected Behavior Before Changes

# Expected Behavior After Changes

- Only CSV parser is available.
- Parser uses default field settings from Bulkrax.
- Brings in empty file for custom parser mapping work in case it is needed.

# Screenshots / Video

<details>
<summary></summary>

Test import with file 
[demo.zip](https://github.com/user-attachments/files/19438576/demo.zip)


![screencapture-cat-wvu-test-importers-1-2025-03-24-17_49_35](https://github.com/user-attachments/assets/fcb2e005-7a5f-40d9-bff8-ab324ccd70aa)

</details>

# Notes
It doesn't appear that any custom configuration is needed simply for use with flexible metadata. This will need to be investigated further as we work on the flex metadata & controlled vocabularies tickets.