### PR TITLE
update-submodule-hyku-ac07ef6a

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_TAG=81b04ee8
+ARG BASE_TAG=ac07ef6a
+
 FROM ghcr.io/samvera/hyku/base:${BASE_TAG} AS hyku-knap-base
 # This is specifically NOT $APP_PATH but the parent directory
 COPY --chown=1001:101 . /app/samvera

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,9 +79,19 @@ services:
       - "5432:5432"
 
   base:
+    <<: *app
     extends:
       file: hyrax-webapp/docker-compose.yml
       service: base
+    build:
+      context: .
+      target: hyku-knap-base
+      cache_from:
+        - ghcr.io/samvera/hyku/base:latest
+      args:
+        BUILDKIT_INLINE_CACHE: 1
+        APP_PATH: ./hyrax-webapp
+        BASE_TAG: ${BASE_TAG:-latest}
     image: ghcr.io/samvera/hyku/base:${BASE_TAG:-latest}
     command: bash -l -c "echo 'base is only used for building base images, which in turn reduces image build times. It does not need to be run'"
 


### PR DESCRIPTION
Update pin to use fresh off main hyku sha for submodule and update base to actually build the base_tag we are passing in the Dockerfile

ref hyku pr: https://github.com/samvera/hyku/commit/ac07ef6a75cca36edc5b272bf17701d90ef26e54

# Story
Update hyku submodule to sha ac07ef6a, the big change is that is where the change was made for pinning a version of the forked willow_sword gem which was causing hardlink issues when building the image and bundling in ci
